### PR TITLE
feat: add parsing of primary_category, categories and html_url

### DIFF
--- a/src/fetch_arxivs.rs
+++ b/src/fetch_arxivs.rs
@@ -63,12 +63,47 @@ fn parse_data(body: String) -> Result<Vec<Arxiv>> {
                         arxiv.authors.push(author);
                     }
                 }
+                "primary_category" => {
+                    if let Some(attribute) = attributes
+                        .iter()
+                        .find(|attr| attr.name.local_name == "term")
+                    {
+                        arxiv.primary_category = attribute.value.clone();
+                    }
+                }
+                "category" => {
+                    if let Some(attribute) = attributes
+                        .iter()
+                        .find(|attr| attr.name.local_name == "term")
+                    {
+                        arxiv.categories.push(attribute.value.clone());
+                    }
+                }
                 "link" => {
-                    if attributes[0].value == "pdf" {
-                        arxiv.pdf_url = format!(
-                            "{}.pdf",
-                            attributes[1].value.replacen("http", "https", 1).clone()
-                        );
+                    if attributes
+                        .iter()
+                        .any(|attr| attr.name.local_name == "title" && attr.value == "pdf")
+                    {
+                        if let Some(attribute) = attributes
+                            .iter()
+                            .find(|attr| attr.name.local_name == "href")
+                        {
+                            arxiv.pdf_url = format!(
+                                "{}.pdf",
+                                attribute.value.replacen("http", "https", 1).clone()
+                            );
+                        }
+                    }
+                    if attributes
+                        .iter()
+                        .any(|attr| attr.name.local_name == "type" && attr.value == "text/html")
+                    {
+                        if let Some(attribute) = attributes
+                            .iter()
+                            .find(|attr| attr.name.local_name == "href")
+                        {
+                            arxiv.html_url = attribute.value.replacen("http", "https", 1).clone();
+                        }
                     }
                 }
                 "comment" => {

--- a/src/models/common.rs
+++ b/src/models/common.rs
@@ -7,7 +7,10 @@ pub struct Arxiv {
     pub title: String,
     pub summary: String,
     pub authors: Vec<String>,
+    pub primary_category: String,
+    pub categories: Vec<String>,
     pub pdf_url: String,
+    pub html_url: String,
     pub comment: Option<String>,
 }
 


### PR DESCRIPTION
Adding parsing of primary_category, categories and html_url

I have improved the parsing of link type as well, previously link parsing relied that first attribute will always be of type "pdf" 

cc @moisutsu 